### PR TITLE
Added ability to use string integers for encoding.

### DIFF
--- a/lib/ex_web3_ec_recover/signed_type/encoder/hexstring_encoder.ex
+++ b/lib/ex_web3_ec_recover/signed_type/encoder/hexstring_encoder.ex
@@ -20,6 +20,12 @@ defmodule ExWeb3EcRecover.SignedType.HexStringEncoder do
   def encode_value("uint" <> bytes_length, value) when is_number(value),
     do: encode_value_atomic("uint", bytes_length, value)
 
+  def encode_value("int" <> bytes_length, value) when is_binary(value),
+    do: encode_value_atomic("int", bytes_length, String.to_integer(value))
+
+  def encode_value("uint" <> bytes_length, value) when is_binary(value),
+    do: encode_value_atomic("uint", bytes_length, String.to_integer(value))
+
   def encode_value("bytes" <> bytes_length, value) do
     value = ExWeb3EcRecover.parse_hex(value)
     encode_value_atomic("bytes", bytes_length, value)

--- a/test/real_world_cases/ox_protocol_test.exs
+++ b/test/real_world_cases/ox_protocol_test.exs
@@ -40,7 +40,7 @@ defmodule ExWeb3EcRecover.RealWorldCases.OxProtocolTest do
       domain: %{
         "name" => "0x Protocol",
         "version" => "3.0.0",
-        "chainId" => 137,
+        "chainId" => "137",
         "verifyingContract" => "0xfede379e48c873c75f3cc0c81f7c784ad730a8f7"
       },
       message: %{
@@ -48,10 +48,10 @@ defmodule ExWeb3EcRecover.RealWorldCases.OxProtocolTest do
         "takerAddress" => "0x0000000000000000000000000000000000000000",
         "senderAddress" => "0x0000000000000000000000000000000000000000",
         "feeRecipientAddress" => "0x0000000000000000000000000000000000000000",
-        "expirationTimeSeconds" => 1_641_635_545,
-        "salt" => 1,
-        "makerAssetAmount" => 1,
-        "takerAssetAmount" => 50_000_000_000_000_000,
+        "expirationTimeSeconds" => "1641635545",
+        "salt" => "1",
+        "makerAssetAmount" => "1",
+        "takerAssetAmount" => "50000000000000000",
         "makerAssetData" =>
           "02571792000000000000000000000000a5f1ea7df861952863df2e8d1312f7305d" <>
             "abf215000000000000000000000000000000000000000000000000000000000000" <>
@@ -60,8 +60,8 @@ defmodule ExWeb3EcRecover.RealWorldCases.OxProtocolTest do
           "0xf47261b00000000000000000000000007ceb23fd6bc0add59e62ac25578270cff1b9f619",
         "takerFeeAssetData" => "0x",
         "makerFeeAssetData" => "0x",
-        "takerFee" => 0,
-        "makerFee" => 0
+        "takerFee" => "0",
+        "makerFee" => "0"
       }
     }
 

--- a/test/signed_type_test.exs
+++ b/test/signed_type_test.exs
@@ -55,6 +55,37 @@ defmodule ExWeb3EcRecover.SignedTypeTest do
                |> Base.encode16(case: :lower)
     end
 
+    test "with integers as strings or numbers" do
+      types = %{
+        "Message" => [
+          %{"name" => "data1", "type" => "int256"},
+          %{"name" => "data2", "type" => "uint256"},
+        ]
+      }
+
+      primary_type = "Message"
+
+      message_as_strings = %{
+        "data1" => "1709",
+        "data2" => "2023"
+      }
+
+      message_as_numbers = %{
+        "data1" => 1709,
+        "data2" => 2023
+      }
+
+      # This was generated with metamask
+      target =
+        "e52790096313e8f1f8c819063bbc1dd12e680e58d2d8b725cb474c0e7c0cbb70"
+        |> String.downcase()
+
+      strings_signed = SignedType.hash_message(message_as_strings, types, primary_type)
+      numbers_signed = SignedType.hash_message(message_as_numbers, types, primary_type)
+      assert strings_signed == numbers_signed
+      assert Base.encode16(strings_signed, case: :lower) == target
+    end
+
     test "containing references" do
       types = %{
         "Message" => [


### PR DESCRIPTION
All the JS clients / servers put integers as strings due to JS engine number max size. Added availability to use strings where integer should be so it is easier to integrate.